### PR TITLE
retain various properties of tabs after restore

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -37,7 +37,26 @@ function generate_UUID() {
 function storeTabs(tabs) {
   const validTabs = tabs.filter((tab) => !tab.url.startsWith("about:"));
 
-  const storedTabs = validTabs.map((tab) => (tab ));
+  let allowedProperties = [
+    "url",
+    "cookieStoreId",
+    "openInReaderMode",
+    "pinned",
+  ];
+
+  const storedTabs = validTabs.map((tab) => {
+    return {
+      url: tab.url,
+      id: tab.id,
+      title: tab.title,
+      create: Object.keys(tab)
+        .filter((key) => allowedProperties.includes(key))
+        .reduce((obj, key) => {
+          obj[key] = tab[key];
+          return obj;
+        }, {}),
+    };
+  });
 
   let groupId = generate_UUID();
 

--- a/js/popup.js
+++ b/js/popup.js
@@ -37,12 +37,7 @@ function generate_UUID() {
 function storeTabs(tabs) {
   const validTabs = tabs.filter((tab) => !tab.url.startsWith("about:"));
 
-  const storedTabs = validTabs.map((tab) => ({
-    id: tab.id,
-    title: tab.title,
-    url: tab.url,
-    cookieStoreId: tab.cookieStoreId,
-  }));
+  const storedTabs = validTabs.map((tab) => (tab ));
 
   let groupId = generate_UUID();
 

--- a/js/tab-manager.js
+++ b/js/tab-manager.js
@@ -1,24 +1,7 @@
 function restore(group) {
   console.log(group);
   group.forEach((tab) => {
-    let allowedProperties = [
-      "url",
-      "cookieStoreId",
-      "openInReaderMode",
-      "pinned",
-    ];
-
-    const createdTab = Object.keys(tab)
-      .filter((key) => allowedProperties.includes(key))
-      .reduce((obj, key) => {
-        obj[key] = tab[key];
-        return obj;
-      }, {});
-
-    console.log(createdTab);
-    console.log({ url: tab.url });
-
-    browser.tabs.create(createdTab).catch((err) => console.debug(err));
+    browser.tabs.create(tab.create).catch((err) => console.debug(err));
   });
 }
 

--- a/js/tab-manager.js
+++ b/js/tab-manager.js
@@ -1,11 +1,24 @@
 function restore(group) {
-  group.forEach(({ url, cookieStoreId }) => {
-    let tab = {};
-    tab.url = url;
-    if (cookieStoreId) {
-      tab.cookieStoreId = cookieStoreId;
-    }
-    browser.tabs.create(tab).catch((err) => console.debug(err));
+  console.log(group);
+  group.forEach((tab) => {
+    let allowedProperties = [
+      "url",
+      "cookieStoreId",
+      "openInReaderMode",
+      "pinned",
+    ];
+
+    const createdTab = Object.keys(tab)
+      .filter((key) => allowedProperties.includes(key))
+      .reduce((obj, key) => {
+        obj[key] = tab[key];
+        return obj;
+      }, {});
+
+    console.log(createdTab);
+    console.log({ url: tab.url });
+
+    browser.tabs.create(createdTab).catch((err) => console.debug(err));
   });
 }
 


### PR DESCRIPTION
It basically retains the various parameters which tabs.create() accepts. Ref https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/tabs/create#parameters